### PR TITLE
Upgrade to the Codehaus Cargo Maven 3 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
         <plugins>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
-                <artifactId>cargo-maven2-plugin</artifactId>
+                <artifactId>cargo-maven3-plugin</artifactId>
                 <!--SNIP-->
                 <configuration>
                     <container>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -36,7 +36,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -43,7 +43,7 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -327,7 +327,7 @@
         <plugins>
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven2-plugin</artifactId>
+            <artifactId>cargo-maven3-plugin</artifactId>
             <configuration>
               <configuration>
                 <configfiles>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -53,7 +53,7 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <configuration>
           <configuration>
             <type>runtime</type>


### PR DESCRIPTION
The Codehaus Cargo Maven 2 plugin was retired in 2021, for a Maven 3 version. All configurations remain 100% compatible.